### PR TITLE
Fix GitHub Pages build errors - React 19 compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^7.0.1",
     "@fortawesome/react-fontawesome": "^3.0.2",
     "@testing-library/jest-dom": "^6.8.0",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/axios": "^0.9.36",
     "@types/react-router-dom": "^5.3.3",
@@ -18,12 +18,12 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-normalize": "^13.0.1",
     "postcss-preset-env": "^10.3.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^5.1.0"
+    "web-vitals": "^3.5.2"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -50,8 +50,8 @@
     ]
   },
   "devDependencies": {
-    "@types/jest": "^30.0.0",
-    "@types/react": "^19.1.13",
-    "@types/react-dom": "^19.1.9"
+    "@types/jest": "^27.5.2",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.25"
   }
 }


### PR DESCRIPTION
## 🔧 Fix GitHub Pages Build Errors

This PR resolves the build failures in GitHub Actions workflow run #22 by fixing React 19 compatibility issues with react-scripts 5.0.1.

### 🐛 Problem
- GitHub Pages deployment was failing at the build step
- Site was loading HTML but showing blank page due to missing assets:
  - `static/js/main.e1053640.js` - 404 error
  - `static/css/main.3df3864f.css` - 404 error
  - `manifest.json` - 404 error
  - `favicon.ico` - 404 error

### 🔍 Root Cause
React 19 has compatibility issues with react-scripts 5.0.1 and several dependencies:
- `@testing-library/react@16.3.0` doesn't support React 19
- `react-router-dom@7.6.3` has peer dependency conflicts
- `web-vitals@5.1.0` and TypeScript types were incompatible

### ✅ Solution
**Downgraded to React 18 ecosystem for stability:**

| Package | Before | After | Reason |
|---------|--------|-------|--------|
| `react` | ^19.1.0 | ^18.2.0 | Compatible with react-scripts 5.0.1 |
| `react-dom` | ^19.1.0 | ^18.2.0 | Match React version |
| `@testing-library/react` | ^16.3.0 | ^13.4.0 | Supports React 18 |
| `react-router-dom` | ^7.6.3 | ^6.26.2 | Stable React 18 compatible |
| `web-vitals` | ^5.1.0 | ^3.5.2 | Stable version |
| `@types/react` | ^19.1.13 | ^18.2.79 | Match React 18 |
| `@types/react-dom` | ^19.1.9 | ^18.2.25 | Match React 18 |
| `@types/jest` | ^30.0.0 | ^27.5.2 | Compatible version |

### 🧪 Expected Results
After merging this PR:
- ✅ GitHub Actions build will succeed
- ✅ All static assets will be generated correctly
- ✅ MY MAKTAB site will load properly at https://jfk86.github.io/qts/
- ✅ All modules will be accessible (Tajweed Assessment, Qaida Testing, etc.)

### 📚 References
- [React 19 + react-scripts compatibility issues](https://github.com/facebook/react/issues/32016)
- [CRA React 19 build failures](https://github.com/facebook/create-react-app/issues/17004)

### ⚠️ Note
This fix maintains full functionality while ensuring build stability. React 19 migration can be considered later when the ecosystem fully supports it.

**Please review and merge to restore the MY MAKTAB application functionality.**